### PR TITLE
Added enable, disable, close, open methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "bbhelp"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "url": "https://github.com/blackbaud/help-client/issues"
   },
   "homepage": "https://github.com/blackbaud/help-client#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@types/tapable": "^0.2.4"
+  },
   "devDependencies": {
     "@types/core-js": "0.9.41",
     "@types/jasmine": "2.5.47",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/blackbaud/help-client#readme",
   "dependencies": {
-    "@types/tapable": "^0.2.4"
+    "@types/tapable": "0.2.4"
   },
   "devDependencies": {
     "@types/core-js": "0.9.41",

--- a/src/help.spec.ts
+++ b/src/help.spec.ts
@@ -215,9 +215,7 @@ describe('help-client', () => {
       .then()
       .then(() => {
         BBHelpClient.setCurrentHelpKey(newHelpKey);
-        return BBHelpClient.openWidgetToHelpKey();
-      })
-      .then(() => {
+        BBHelpClient.openWidgetToHelpKey();
         expect(helpOpenSpy).toHaveBeenCalledWith(newHelpKey);
         done();
       })
@@ -236,9 +234,7 @@ describe('help-client', () => {
       .load()
       .then(() => {
         BBHelpClient.setCurrentHelpKey(newHelpKey);
-        return BBHelpClient.openWidgetToHelpKey('foo.html');
-      })
-      .then(() => {
+        BBHelpClient.openWidgetToHelpKey('foo.html');
         expect(helpOpenSpy).toHaveBeenCalledWith('foo.html');
         done();
       })
@@ -257,15 +253,11 @@ describe('help-client', () => {
     BBHelpClient.load()
       .then(() => {
         expect(helpOpenSpy).not.toHaveBeenCalled();
-        return BBHelpClient.openWidget();
-      })
-      .then(() => {
+        BBHelpClient.openWidget();
         expect(helpOpenSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.opened).toBe(true);
         expect(helpCloseSpy).not.toHaveBeenCalled();
-        return BBHelpClient.closeWidget();
-      })
-      .then(() => {
+        BBHelpClient.closeWidget();
         expect(helpCloseSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.opened).toBe(false);
         done();
@@ -303,7 +295,38 @@ describe('help-client', () => {
       });
   });
 
-  it('should disable and enable and close the widget', (done) => {
+  it('should disable and enable the widget', (done) => {
+    const helpDisableSpy = spyOn(fakeHelp.HelpWidget, 'disableWidget').and.callThrough();
+    const helpEnableSpy = spyOn(fakeHelp.HelpWidget, 'enableWidget').and.callThrough();
+    const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
+    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
+      return Promise.resolve();
+    });
+
+    BBHelpClient.load()
+      .then(() => {
+        expect(helpDisableSpy).not.toHaveBeenCalled();
+        return BBHelpClient.openWidget();
+      })
+      .then(() => {
+        expect(fakeHelp.HelpWidget.opened).toBe(true);
+        return BBHelpClient.disableWidget();
+      })
+      .then(() => {
+        expect(fakeHelp.HelpWidget.disabled).toBe(true);
+        return BBHelpClient.enableWidget();
+      })
+      .then(() => {
+        expect(helpEnableSpy).toHaveBeenCalled();
+        expect(fakeHelp.HelpWidget.disabled).toBe(false);
+        done();
+      })
+      .catch(() => {
+        done.fail('The help widget was not configured.');
+      });
+  });
+
+  it('should close the widget on disabled', (done) => {
     const helpDisableSpy = spyOn(fakeHelp.HelpWidget, 'disableWidget').and.callThrough();
     const helpEnableSpy = spyOn(fakeHelp.HelpWidget, 'enableWidget').and.callThrough();
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
@@ -324,11 +347,6 @@ describe('help-client', () => {
         expect(helpDisableSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.opened).toBe(false);
         expect(fakeHelp.HelpWidget.disabled).toBe(true);
-        return BBHelpClient.enableWidget();
-      })
-      .then(() => {
-        expect(helpEnableSpy).toHaveBeenCalled();
-        expect(fakeHelp.HelpWidget.disabled).toBe(false);
         done();
       })
       .catch(() => {
@@ -336,24 +354,7 @@ describe('help-client', () => {
       });
   });
 
-  it('should execute a given BBHelp action only when both client and widget are ready', (done) => {
-    const callbackSpy = spyOn(BBHelpClient, 'openWidget').and.callThrough();
-    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
-      return Promise.resolve();
-    });
-
-    BBHelpClient.load()
-      .then(() => {
-        return BBHelpClient.openWidget();
-      })
-      .then(() => {
-        expect(readySpy).toHaveBeenCalled();
-        expect(callbackSpy).toHaveBeenCalled();
-        done();
-      });
-  });
-
-  it('Should resolve as ready when the load method has completed.', (done) => {
+  it('should resolve as ready when the load method has completed.', (done) => {
     const readySpy = spyOn(BBHelpClient, 'ready').and.callThrough();
     BBHelpClient.load()
       .then(() => {
@@ -365,7 +366,7 @@ describe('help-client', () => {
       });
   });
 
-  it('Should log an error if the HelpWidget ready method fails', (done) => {
+  it('should log an error if the HelpWidget ready method fails', (done) => {
     const errMessage = 'The Help Widget failed to load.';
     const consoleSpy = spyOn(console, 'error').and.callThrough();
     const widgetSpy = spyOn(fakeHelp.HelpWidget, 'ready').and.callFake(() => {

--- a/src/help.spec.ts
+++ b/src/help.spec.ts
@@ -38,6 +38,7 @@ describe('help-client', () => {
     registerScriptSpy.calls.reset();
     fakeHelp = {
       HelpWidget: {
+        disabled: false,
         opened: false,
         close() {
           this.opened = false;
@@ -51,6 +52,13 @@ describe('help-client', () => {
         },
         toggleOpen() {
           this.opened ? this.close() : this.open();
+        },
+        disableWidget() {
+          this.opened = false;
+          this.disabled = true;
+        },
+        enableWidget() {
+          this.disabled = false;
         }
       }
     };
@@ -219,6 +227,27 @@ describe('help-client', () => {
       });
   });
 
+  it('should open and close the widget', (done) => {
+    const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
+    const helpCloseSpy = spyOn(fakeHelp.HelpWidget, 'close').and.callThrough();
+
+    BBHelpClient.load()
+      .then(() => {
+        expect(helpOpenSpy).not.toHaveBeenCalled();
+        BBHelpClient.openWidget();
+        expect(helpOpenSpy).toHaveBeenCalled();
+        expect(fakeHelp.HelpWidget.opened).toBe(true);
+        expect(helpCloseSpy).not.toHaveBeenCalled();
+        BBHelpClient.closeWidget();
+        expect(helpCloseSpy).toHaveBeenCalled();
+        expect(fakeHelp.HelpWidget.opened).toBe(false);
+        done();
+      })
+      .catch(() => {
+        done.fail('The help widget was not configured.');
+      });
+  });
+
   it('should toggle the widget between open and closed', (done) => {
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
     const helpCloseSpy = spyOn(fakeHelp.HelpWidget, 'close').and.callThrough();
@@ -233,6 +262,30 @@ describe('help-client', () => {
         BBHelpClient.toggleOpen();
         expect(helpCloseSpy).toHaveBeenCalled();
         expect(helpToggleSpy).toHaveBeenCalledTimes(2);
+        done();
+      })
+      .catch(() => {
+        done.fail('The help widget was not configured.');
+      });
+  });
+
+  it('should disable and enable and close the widget', (done) => {
+    const helpDisableSpy = spyOn(fakeHelp.HelpWidget, 'disableWidget').and.callThrough();
+    const helpEnableSpy = spyOn(fakeHelp.HelpWidget, 'enableWidget').and.callThrough();
+    const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
+
+    BBHelpClient.load()
+      .then(() => {
+        expect(helpDisableSpy).not.toHaveBeenCalled();
+        BBHelpClient.openWidget();
+        expect(fakeHelp.HelpWidget.opened).toBe(true);
+        BBHelpClient.disableWidget();
+        expect(helpDisableSpy).toHaveBeenCalled();
+        expect(fakeHelp.HelpWidget.opened).toBe(false);
+        expect(fakeHelp.HelpWidget.disabled).toBe(true);
+        BBHelpClient.enableWidget();
+        expect(helpEnableSpy).toHaveBeenCalled();
+        expect(fakeHelp.HelpWidget.disabled).toBe(false);
         done();
       })
       .catch(() => {

--- a/src/help.spec.ts
+++ b/src/help.spec.ts
@@ -5,6 +5,7 @@ import * as utils from './register-script';
 
 describe('help-client', () => {
   const testCss: string = '{ background-color: red }';
+  let originalTimeout: number;
   let registerScriptSpy: jasmine.Spy;
   let fakeHelp: any;
   let headStyles = '';
@@ -35,6 +36,9 @@ describe('help-client', () => {
   });
 
   beforeEach(() => {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
     registerScriptSpy.calls.reset();
     fakeHelp = {
       HelpWidget: {
@@ -72,6 +76,7 @@ describe('help-client', () => {
   });
 
   afterEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     registerScriptSpy.calls.reset();
     BBHelpClient['defaultHelpKey'] = 'default.html';
     BBHelpClient['currentHelpKey'] = undefined;
@@ -200,16 +205,19 @@ describe('help-client', () => {
 
   it('should open the widget to the currentHelpKey if no helpKey is passed as a parameter', (done) => {
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callFake((actionCallback: () => void) => {
-      actionCallback();
+    const ready = spyOn(BBHelpClient, 'ready').and.callFake(() => {
+      return Promise.resolve();
     });
 
     const newHelpKey = 'test-key.html';
     BBHelpClient
       .load()
+      .then()
       .then(() => {
         BBHelpClient.setCurrentHelpKey(newHelpKey);
-        BBHelpClient.openWidgetToHelpKey();
+        return BBHelpClient.openWidgetToHelpKey();
+      })
+      .then(() => {
         expect(helpOpenSpy).toHaveBeenCalledWith(newHelpKey);
         done();
       })
@@ -220,15 +228,17 @@ describe('help-client', () => {
 
   it('should open the widget to a specified helpKey if one is passed as a parameter', (done) => {
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callFake((actionCallback: () => void) => {
-      actionCallback();
+    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
+      return Promise.resolve();
     });
     const newHelpKey = 'test-key.html';
     BBHelpClient
       .load()
       .then(() => {
         BBHelpClient.setCurrentHelpKey(newHelpKey);
-        BBHelpClient.openWidgetToHelpKey('foo.html');
+        return BBHelpClient.openWidgetToHelpKey('foo.html');
+      })
+      .then(() => {
         expect(helpOpenSpy).toHaveBeenCalledWith('foo.html');
         done();
       })
@@ -240,18 +250,22 @@ describe('help-client', () => {
   it('should open and close the widget', (done) => {
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
     const helpCloseSpy = spyOn(fakeHelp.HelpWidget, 'close').and.callThrough();
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callFake((actionCallback: () => void) => {
-      actionCallback();
+    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
+      return Promise.resolve();
     });
 
     BBHelpClient.load()
       .then(() => {
         expect(helpOpenSpy).not.toHaveBeenCalled();
-        BBHelpClient.openWidget();
+        return BBHelpClient.openWidget();
+      })
+      .then(() => {
         expect(helpOpenSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.opened).toBe(true);
         expect(helpCloseSpy).not.toHaveBeenCalled();
-        BBHelpClient.closeWidget();
+        return BBHelpClient.closeWidget();
+      })
+      .then(() => {
         expect(helpCloseSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.opened).toBe(false);
         done();
@@ -265,17 +279,21 @@ describe('help-client', () => {
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
     const helpCloseSpy = spyOn(fakeHelp.HelpWidget, 'close').and.callThrough();
     const helpToggleSpy = spyOn(fakeHelp.HelpWidget, 'toggleOpen').and.callThrough();
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callFake((actionCallback: () => void) => {
-      actionCallback();
+    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
+      return Promise.resolve();
     });
 
     BBHelpClient.load()
       .then(() => {
         expect(helpOpenSpy).not.toHaveBeenCalled();
-        BBHelpClient.toggleOpen();
+        return BBHelpClient.toggleOpen();
+      })
+      .then(() => {
         expect(helpOpenSpy).toHaveBeenCalled();
         expect(helpCloseSpy).not.toHaveBeenCalled();
-        BBHelpClient.toggleOpen();
+        return BBHelpClient.toggleOpen();
+      })
+      .then(() => {
         expect(helpCloseSpy).toHaveBeenCalled();
         expect(helpToggleSpy).toHaveBeenCalledTimes(2);
         done();
@@ -289,20 +307,26 @@ describe('help-client', () => {
     const helpDisableSpy = spyOn(fakeHelp.HelpWidget, 'disableWidget').and.callThrough();
     const helpEnableSpy = spyOn(fakeHelp.HelpWidget, 'enableWidget').and.callThrough();
     const helpOpenSpy = spyOn(fakeHelp.HelpWidget, 'open').and.callThrough();
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callFake((actionCallback: () => void) => {
-      actionCallback();
+    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
+      return Promise.resolve();
     });
 
     BBHelpClient.load()
       .then(() => {
         expect(helpDisableSpy).not.toHaveBeenCalled();
-        BBHelpClient.openWidget();
+        return BBHelpClient.openWidget();
+      })
+      .then(() => {
         expect(fakeHelp.HelpWidget.opened).toBe(true);
-        BBHelpClient.disableWidget();
+        return BBHelpClient.disableWidget();
+      })
+      .then(() => {
         expect(helpDisableSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.opened).toBe(false);
         expect(fakeHelp.HelpWidget.disabled).toBe(true);
-        BBHelpClient.enableWidget();
+        return BBHelpClient.enableWidget();
+      })
+      .then(() => {
         expect(helpEnableSpy).toHaveBeenCalled();
         expect(fakeHelp.HelpWidget.disabled).toBe(false);
         done();
@@ -313,7 +337,6 @@ describe('help-client', () => {
   });
 
   it('should execute a given BBHelp action only when both client and widget are ready', (done) => {
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callThrough();
     const callbackSpy = spyOn(BBHelpClient, 'openWidget').and.callThrough();
     const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
       return Promise.resolve();
@@ -321,62 +344,52 @@ describe('help-client', () => {
 
     BBHelpClient.load()
       .then(() => {
-        BBHelpClient.executeWhenReady(() => {
-          BBHelpClient.openWidget();
-        })
-        .then(() => {
-          expect(executeSpy).toHaveBeenCalled();
-          expect(callbackSpy).toHaveBeenCalled();
-          done();
-        });
-      });
-  });
-
-  it('should log an error if the ready check fails.', (done) => {
-    const executeSpy = spyOn(BBHelpClient, 'executeWhenReady').and.callThrough();
-    const callbackSpy = spyOn(BBHelpClient, 'openWidget').and.callThrough();
-    const consoleSpy = spyOn(console, 'error').and.callThrough();
-    const errMessage = 'error message';
-    const readySpy = spyOn(BBHelpClient, 'ready').and.callFake(() => {
-      return Promise.reject(errMessage);
-    });
-
-    BBHelpClient.load()
+        return BBHelpClient.openWidget();
+      })
       .then(() => {
-        BBHelpClient.executeWhenReady(() => {
-          BBHelpClient.openWidget();
-        })
-        .then(() => {
-          expect(executeSpy).toHaveBeenCalled();
-          expect(callbackSpy).not.toHaveBeenCalled();
-          expect(consoleSpy).toHaveBeenCalledWith(errMessage);
-          done();
-        });
+        expect(readySpy).toHaveBeenCalled();
+        expect(callbackSpy).toHaveBeenCalled();
+        done();
       });
   });
 
   it('Should resolve as ready when the load method has completed.', (done) => {
     const readySpy = spyOn(BBHelpClient, 'ready').and.callThrough();
-
     BBHelpClient.load()
       .then(() => {
-        BBHelpClient.ready()
-        .then(() => {
-          expect(readySpy).toHaveBeenCalled();
-          done();
-        });
+        return BBHelpClient.ready();
+      })
+      .then(() => {
+        expect(readySpy).toHaveBeenCalled();
+        done();
       });
   });
 
-  it('should err if the widget doesn\'t load before MAX_ITERATIONS are reached', (done) => {
-    const readySpy = spyOn(BBHelpClient, 'ready').and.callThrough();
-    BBHelpClient['MAX_ITERATIONS'] = 3;
+  it('Should log an error if the HelpWidget ready method fails', (done) => {
+    const errMessage = 'The Help Widget failed to load.';
+    const consoleSpy = spyOn(console, 'error').and.callThrough();
+    const widgetSpy = spyOn(fakeHelp.HelpWidget, 'ready').and.callFake(() => {
+      return Promise.reject(errMessage);
+    });
+    BBHelpClient.load()
+      .then(() => {
+        return BBHelpClient.ready();
+      })
+      .then(() => {
+        expect(widgetSpy).toHaveBeenCalled();
+        expect(errMessage).toBe('The Help Widget failed to load.');
+        expect(consoleSpy).toHaveBeenCalledWith(errMessage);
+        done();
+      });
+  });
+
+  it('should err if the widget doesn\'t load before maxIterations are reached', (done) => {
+    const errMessage = 'The Help Widget failed to load.';
+    const consoleSpy = spyOn(console, 'error').and.callThrough();
     BBHelpClient['widgetLoaded'] = false;
     BBHelpClient.ready()
-      .then()
-      .catch((err) => {
-        expect(readySpy).toHaveBeenCalled();
-        expect(err).toBe('The Help Widget failed to load.');
+      .then(() => {
+        expect(consoleSpy).toHaveBeenCalledWith('The Help Widget failed to load.');
         done();
       });
   });

--- a/src/help.ts
+++ b/src/help.ts
@@ -44,8 +44,7 @@ export abstract class BBHelpClient {
   }
 
   public static openWidgetToHelpKey(helpKey: string = BBHelpClient.currentHelpKey): void {
-    BBHelpClient.executeWhenReady(
-      () => {
+    BBHelpClient.executeWhenReady(() => {
         BBHELP.HelpWidget.open(helpKey);
       });
   }
@@ -55,26 +54,36 @@ export abstract class BBHelpClient {
   }
 
   public static toggleOpen(): void {
-    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.toggleOpen);
+    BBHelpClient.executeWhenReady(() => {
+      BBHELP.HelpWidget.toggleOpen();
+    });
   }
 
   public static openWidget(): void {
-    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.open);
+    BBHelpClient.executeWhenReady(() => {
+      BBHELP.HelpWidget.open();
+    });
   }
 
   public static closeWidget(): void {
-    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.close);
+    BBHelpClient.executeWhenReady(() => {
+      BBHELP.HelpWidget.close();
+    });
   }
 
   public static disableWidget(): void {
-    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.disableWidget);
+    BBHelpClient.executeWhenReady(() => {
+      BBHELP.HelpWidget.disableWidget();
+    });
   }
 
   public static enableWidget(): void {
-    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.enableWidget);
+    BBHelpClient.executeWhenReady(() => {
+      BBHELP.HelpWidget.enableWidget();
+    });
   }
 
-  private static executeWhenReady(actionCallback: Function) {
+  private static executeWhenReady(actionCallback: Function): void {
     BBHelpClient.ready()
       .then(() => {
         actionCallback();
@@ -84,7 +93,7 @@ export abstract class BBHelpClient {
       });
   }
 
-  private static ready() {
+  private static ready(): Promise<any> {
     return new Promise((resolve, reject) => {
       let readyAttempts: number = 0;
       const duration: number = 100;

--- a/src/help.ts
+++ b/src/help.ts
@@ -25,7 +25,7 @@ export abstract class BBHelpClient {
 
     config.getCurrentHelpKey = BBHelpClient.getCurrentHelpKey;
 
-    return registerScript('https://cdn-dev.blackbaudcloud.com/bb-help/bb-help.js')
+    return registerScript('https://cdn.blackbaudcloud.com/bb-help/bb-help.js')
       .then(() => {
         BBHelpClient.addStyles();
         // Initialize the widget.

--- a/src/help.ts
+++ b/src/help.ts
@@ -45,10 +45,7 @@ export abstract class BBHelpClient {
   }
 
   public static openWidgetToHelpKey(helpKey: string = BBHelpClient.currentHelpKey): void {
-    BBHelpClient.ready()
-      .then(() => {
-        BBHELP.HelpWidget.open(helpKey);
-      });
+    BBHELP.HelpWidget.open(helpKey);
   }
 
   public static getCurrentHelpKey(): string {
@@ -56,35 +53,26 @@ export abstract class BBHelpClient {
   }
 
   public static toggleOpen(): void {
-    BBHelpClient.ready()
-      .then(() => {
-        BBHELP.HelpWidget.toggleOpen();
-      });
+    BBHELP.HelpWidget.toggleOpen();
   }
 
   public static openWidget(): void {
-    BBHelpClient.ready()
-      .then(() => {
-        BBHELP.HelpWidget.open();
-      });
+    BBHELP.HelpWidget.open();
   }
 
   public static closeWidget(): void {
-    BBHelpClient.ready()
-      .then(() => {
-        BBHELP.HelpWidget.close();
-      });
+    BBHELP.HelpWidget.close();
   }
 
-  public static disableWidget(): void {
-    BBHelpClient.ready()
+  public static disableWidget(): Promise<any> {
+    return BBHelpClient.ready()
       .then(() => {
         BBHELP.HelpWidget.disableWidget();
       });
   }
 
-  public static enableWidget(): void {
-    BBHelpClient.ready()
+  public static enableWidget(): Promise<any> {
+    return BBHelpClient.ready()
       .then(() => {
         BBHELP.HelpWidget.enableWidget();
       });

--- a/src/help.ts
+++ b/src/help.ts
@@ -5,6 +5,7 @@ import { registerScript } from './register-script';
 export abstract class BBHelpClient {
   private static defaultHelpKey: string = 'default.html';
   private static currentHelpKey: string;
+  private static widgetLoaded: boolean = false;
 
   public static addStyles(): void {
     const css = `
@@ -30,6 +31,7 @@ export abstract class BBHelpClient {
         BBHelpClient.addStyles();
         // Initialize the widget.
         BBHELP.HelpWidget.load(config);
+        BBHelpClient.widgetLoaded = true;
       });
   }
 
@@ -42,7 +44,10 @@ export abstract class BBHelpClient {
   }
 
   public static openWidgetToHelpKey(helpKey: string = BBHelpClient.currentHelpKey): void {
-    BBHELP.HelpWidget.open(helpKey);
+    BBHelpClient.executeWhenReady(
+      () => {
+        BBHELP.HelpWidget.open(helpKey);
+      });
   }
 
   public static getCurrentHelpKey(): string {
@@ -50,22 +55,54 @@ export abstract class BBHelpClient {
   }
 
   public static toggleOpen(): void {
-    BBHELP.HelpWidget.toggleOpen();
+    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.toggleOpen);
   }
 
   public static openWidget(): void {
-    BBHELP.HelpWidget.open();
+    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.open);
   }
 
   public static closeWidget(): void {
-    BBHELP.HelpWidget.close();
+    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.close);
   }
 
   public static disableWidget(): void {
-    BBHELP.HelpWidget.disableWidget();
+    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.disableWidget);
   }
 
   public static enableWidget(): void {
-    BBHELP.HelpWidget.enableWidget();
+    BBHelpClient.executeWhenReady(BBHELP.HelpWidget.enableWidget);
+  }
+
+  private static executeWhenReady(actionCallback: Function) {
+    BBHelpClient.ready()
+      .then(() => {
+        actionCallback();
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  }
+
+  private static ready() {
+    return new Promise((resolve, reject) => {
+      let readyAttempts: number = 0;
+      const duration: number = 100;
+      const maxIterations: number = 100;
+
+      const interval = setInterval(() => {
+        readyAttempts++;
+
+        if (BBHelpClient.widgetLoaded) {
+          clearInterval(interval);
+          return resolve();
+        }
+
+        if (maxIterations >= 100) {
+          clearInterval(interval);
+          return reject('The Help Widget failed to load.');
+        }
+      }, duration);
+    });
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -83,34 +83,36 @@ export abstract class BBHelpClient {
     });
   }
 
-  private static executeWhenReady(actionCallback: Function): void {
+  private static executeWhenReady(actionCallback: () => void): void {
     BBHelpClient.ready()
+      .then(() => {
+        return BBHELP.HelpWidget.ready();
+      })
       .then(() => {
         actionCallback();
       })
-      .catch(err => {
+      .catch((err: string) => {
         console.error(err);
       });
   }
 
   private static ready(): Promise<any> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve: any, reject: any) => {
       let readyAttempts: number = 0;
       const duration: number = 100;
       const maxIterations: number = 100;
 
-      const interval = setInterval(() => {
-        readyAttempts++;
+      const interval: any = setInterval(() => {
+          readyAttempts++;
+          if (BBHelpClient.widgetLoaded) {
+              clearInterval(interval);
+              resolve();
+          }
 
-        if (BBHelpClient.widgetLoaded) {
-          clearInterval(interval);
-          return resolve();
-        }
-
-        if (maxIterations >= 100) {
-          clearInterval(interval);
-          return reject('The Help Widget failed to load.');
-        }
+          if (readyAttempts >= maxIterations) {
+              clearInterval(interval);
+              reject('The Help Widget failed to load.');
+          }
       }, duration);
     });
   }

--- a/src/help.ts
+++ b/src/help.ts
@@ -64,18 +64,12 @@ export abstract class BBHelpClient {
     BBHELP.HelpWidget.close();
   }
 
-  public static disableWidget(): Promise<any> {
-    return BBHelpClient.ready()
-      .then(() => {
-        BBHELP.HelpWidget.disableWidget();
-      });
+  public static disableWidget(): void {
+    BBHELP.HelpWidget.disableWidget();
   }
 
-  public static enableWidget(): Promise<any> {
-    return BBHelpClient.ready()
-      .then(() => {
-        BBHELP.HelpWidget.enableWidget();
-      });
+  public static enableWidget(): void {
+    BBHELP.HelpWidget.enableWidget();
   }
 
   public static ready(): Promise<any> {

--- a/src/help.ts
+++ b/src/help.ts
@@ -5,7 +5,10 @@ import { registerScript } from './register-script';
 export abstract class BBHelpClient {
   private static defaultHelpKey: string = 'default.html';
   private static currentHelpKey: string;
+
   private static widgetLoaded: boolean = false;
+  private static DURATION: number = 100;
+  private static MAX_ITERATIONS: number = 100;
 
   public static addStyles(): void {
     const css = `
@@ -83,8 +86,8 @@ export abstract class BBHelpClient {
     });
   }
 
-  private static executeWhenReady(actionCallback: () => void): void {
-    BBHelpClient.ready()
+  public static executeWhenReady(actionCallback: () => void): Promise<any> {
+    return BBHelpClient.ready()
       .then(() => {
         return BBHELP.HelpWidget.ready();
       })
@@ -96,24 +99,22 @@ export abstract class BBHelpClient {
       });
   }
 
-  private static ready(): Promise<any> {
+  public static ready(): Promise<any> {
     return new Promise((resolve: any, reject: any) => {
       let readyAttempts: number = 0;
-      const duration: number = 100;
-      const maxIterations: number = 100;
 
       const interval: any = setInterval(() => {
-          readyAttempts++;
-          if (BBHelpClient.widgetLoaded) {
-              clearInterval(interval);
-              resolve();
-          }
+        readyAttempts++;
+        if (BBHelpClient.widgetLoaded) {
+          clearInterval(interval);
+          resolve();
+        }
 
-          if (readyAttempts >= maxIterations) {
-              clearInterval(interval);
-              reject('The Help Widget failed to load.');
-          }
-      }, duration);
+        if (readyAttempts >= BBHelpClient.MAX_ITERATIONS) {
+          clearInterval(interval);
+          reject('The Help Widget failed to load.');
+        }
+      }, BBHelpClient.DURATION);
     });
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -26,7 +26,7 @@ export abstract class BBHelpClient {
 
     config.getCurrentHelpKey = BBHelpClient.getCurrentHelpKey;
 
-    return registerScript('https://cdn.blackbaudcloud.com/bb-help/bb-help.js')
+    return registerScript('https://cdn-dev.blackbaudcloud.com/bb-help/bb-help.js')
       .then(() => {
         BBHelpClient.addStyles();
         // Initialize the widget.

--- a/src/help.ts
+++ b/src/help.ts
@@ -52,4 +52,20 @@ export abstract class BBHelpClient {
   public static toggleOpen(): void {
     BBHELP.HelpWidget.toggleOpen();
   }
+
+  public static openWidget(): void {
+    BBHELP.HelpWidget.open();
+  }
+
+  public static closeWidget(): void {
+    BBHELP.HelpWidget.close();
+  }
+
+  public static disableWidget(): void {
+    BBHELP.HelpWidget.disableWidget();
+  }
+
+  public static enableWidget(): void {
+    BBHELP.HelpWidget.enableWidget();
+  }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -7,8 +7,6 @@ export abstract class BBHelpClient {
   private static currentHelpKey: string;
 
   private static widgetLoaded: boolean = false;
-  private static DURATION: number = 100;
-  private static MAX_ITERATIONS: number = 100;
 
   public static addStyles(): void {
     const css = `
@@ -47,7 +45,8 @@ export abstract class BBHelpClient {
   }
 
   public static openWidgetToHelpKey(helpKey: string = BBHelpClient.currentHelpKey): void {
-    BBHelpClient.executeWhenReady(() => {
+    BBHelpClient.ready()
+      .then(() => {
         BBHELP.HelpWidget.open(helpKey);
       });
   }
@@ -57,49 +56,54 @@ export abstract class BBHelpClient {
   }
 
   public static toggleOpen(): void {
-    BBHelpClient.executeWhenReady(() => {
-      BBHELP.HelpWidget.toggleOpen();
-    });
+    BBHelpClient.ready()
+      .then(() => {
+        BBHELP.HelpWidget.toggleOpen();
+      });
   }
 
   public static openWidget(): void {
-    BBHelpClient.executeWhenReady(() => {
-      BBHELP.HelpWidget.open();
-    });
+    BBHelpClient.ready()
+      .then(() => {
+        BBHELP.HelpWidget.open();
+      });
   }
 
   public static closeWidget(): void {
-    BBHelpClient.executeWhenReady(() => {
-      BBHELP.HelpWidget.close();
-    });
+    BBHelpClient.ready()
+      .then(() => {
+        BBHELP.HelpWidget.close();
+      });
   }
 
   public static disableWidget(): void {
-    BBHelpClient.executeWhenReady(() => {
-      BBHELP.HelpWidget.disableWidget();
-    });
+    BBHelpClient.ready()
+      .then(() => {
+        BBHELP.HelpWidget.disableWidget();
+      });
   }
 
   public static enableWidget(): void {
-    BBHelpClient.executeWhenReady(() => {
-      BBHELP.HelpWidget.enableWidget();
-    });
+    BBHelpClient.ready()
+      .then(() => {
+        BBHELP.HelpWidget.enableWidget();
+      });
   }
 
-  public static executeWhenReady(actionCallback: () => void): Promise<any> {
-    return BBHelpClient.ready()
+  public static ready(): Promise<any> {
+    return BBHelpClient.clientReady()
       .then(() => {
         return BBHELP.HelpWidget.ready();
-      })
-      .then(() => {
-        actionCallback();
       })
       .catch((err: string) => {
         console.error(err);
       });
   }
 
-  public static ready(): Promise<any> {
+  private static clientReady(): Promise<any> {
+    const duration: number = 100;
+    const maxIterations: number = 50;
+
     return new Promise((resolve: any, reject: any) => {
       let readyAttempts: number = 0;
 
@@ -110,11 +114,11 @@ export abstract class BBHelpClient {
           resolve();
         }
 
-        if (readyAttempts >= BBHelpClient.MAX_ITERATIONS) {
+        if (readyAttempts >= maxIterations) {
           clearInterval(interval);
           reject('The Help Widget failed to load.');
         }
-      }, BBHelpClient.DURATION);
+      }, duration);
     });
   }
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -26,7 +26,7 @@ export abstract class BBHelpClient {
 
     config.getCurrentHelpKey = BBHelpClient.getCurrentHelpKey;
 
-    return registerScript('https://cdn-dev.blackbaudcloud.com/bb-help/bb-help.js')
+    return registerScript('https://cdn.blackbaudcloud.com/bb-help/bb-help.js')
       .then(() => {
         BBHelpClient.addStyles();
         // Initialize the widget.

--- a/src/help.ts
+++ b/src/help.ts
@@ -25,7 +25,7 @@ export abstract class BBHelpClient {
 
     config.getCurrentHelpKey = BBHelpClient.getCurrentHelpKey;
 
-    return registerScript('https://cdn.blackbaudcloud.com/bb-help/bb-help.js')
+    return registerScript('https://cdn-dev.blackbaudcloud.com/bb-help/bb-help.js')
       .then(() => {
         BBHelpClient.addStyles();
         // Initialize the widget.


### PR DESCRIPTION
Relies on PRs into 
`Help Widget:` https://github.com/blackbaud/bb-help/pull/131
and 
`Help Library:` https://github.com/blackbaud/skyux-lib-help/pull/29

This feature accomplishes a couple things: 
A) Allows users to disable the Help Widget on specific pages within their apps.  This has been requested by several times, including BB-Labs and K12 recently.
B) Creates a "holder" component for future directives we might add for interacting with the widget. This keeps users Apps organized when they go to find their bb-help settings later.
C) Exposes the base widget's open/close methods for direct access instead of simply toggling.