### PR TITLE
focus invoker

### DIFF
--- a/src/help-widget.spec.ts
+++ b/src/help-widget.spec.ts
@@ -344,8 +344,10 @@ describe('BBHelpHelpWidget', () => {
 
   it ('should respond to action responses, Close Widget', (done) => {
     spyOn(helpWidget, 'close').and.callThrough();
+    spyOn(helpWidget['invoker'], 'focus');
     helpWidget['communicationService'].communicationAction.next('Close Widget');
     expect(helpWidget.close).toHaveBeenCalled();
+    expect(helpWidget['invoker'].focus).toHaveBeenCalled();
     done();
   });
 

--- a/src/help-widget.ts
+++ b/src/help-widget.ts
@@ -181,6 +181,7 @@ export class BBHelpHelpWidget {
   private actionResponse(action: string) {
     switch (action) {
       case 'Close Widget':
+        this.invoker.focus();
         this.close();
         break;
       case 'Child Window Ready':


### PR DESCRIPTION
Waits for close message and focuses the invoker. Decided to put the focus command here since I figure we don't always want the invoker to gain focus on close(), since it can be toggled via button or other functions. 