### PR TITLE
show invoker on mobile height not width

### DIFF
--- a/src/help-widget-renderer.spec.ts
+++ b/src/help-widget-renderer.spec.ts
@@ -1,14 +1,11 @@
 import { BBHelpHelpWidgetRenderer } from './help-widget-renderer';
-import { MockStyleUtility } from './mocks/mock-style-utilty';
 
 const BB_HELP_HIDE_ON_MOBILE_CLASS: string = 'bb-help-hide-on-mobile';
 
 describe('BBHelpHelpWidgetRenderer', () => {
   let widgetRenderer: BBHelpHelpWidgetRenderer;
-  let mockStyleUtility: any;
 
   beforeEach(() => {
-    mockStyleUtility = new MockStyleUtility();
     widgetRenderer = new BBHelpHelpWidgetRenderer();
   });
 

--- a/src/help-widget-style-utility.ts
+++ b/src/help-widget-style-utility.ts
@@ -103,7 +103,7 @@ const mobileCss = `
     right: -100%;
   }
 
-  .bb-help-container-mobile#bb-help-container #bb-help-invoker.bb-help-mobile-width.bb-help-hide-on-mobile {
+  .bb-help-mobile-width.bb-help-hide-on-mobile#bb-help-invoker {
     display: none;
   }
 `;

--- a/src/help-widget-style-utility.ts
+++ b/src/help-widget-style-utility.ts
@@ -103,7 +103,7 @@ const mobileCss = `
     right: -100%;
   }
 
-  .bb-help-container-mobile#bb-help-container #bb-help-invoker.bb-help-hide-on-mobile {
+  .bb-help-container-mobile#bb-help-container #bb-help-invoker.bb-help-mobile-width.bb-help-hide-on-mobile {
     display: none;
   }
 `;

--- a/src/help-widget.spec.ts
+++ b/src/help-widget.spec.ts
@@ -579,7 +579,23 @@ describe('BBHelpHelpWidget', () => {
     done();
   });
 
-  it('should not add the mobile container class when window dimentions are greater than specified values', (done) => {
+  it('should add the mobile width invoker class when screen is below mobile width', (done) => {
+    (window as any).innerWidth = 700;
+    (window as any).innerHeight = 1000;
+    window.dispatchEvent(new Event('resize'));
+    expect(helpWidget['invoker'].classList).toContain('bb-help-mobile-width');
+    done();
+  });
+
+  it('should not add the mobile width invoker class when screen is above mobile width', (done) => {
+    (window as any).innerWidth = 1000;
+    (window as any).innerHeight = 400;
+    window.dispatchEvent(new Event('resize'));
+    expect(helpWidget['invoker'].classList).not.toContain('bb-help-mobile-width');
+    done();
+  });
+
+  it('should not add the mobile container class when window dimensions are greater than specified values', (done) => {
     (window as any).innerWidth = 1000;
     (window as any).innerHeight = 1000;
     window.dispatchEvent(new Event('resize'));

--- a/src/help-widget.ts
+++ b/src/help-widget.ts
@@ -9,6 +9,7 @@ import { BBHelpCommunicationService } from './service/communication.service';
 const HELP_CLOSED_CLASS: string = 'bb-help-closed';
 const MOBILE_CONTAINER_CLASS: string = 'bb-help-container-mobile';
 const DISABLE_TRANSITION: string = 'bb-help-disable-transition';
+const MOBILE_WIDTH_CLASS: string = 'bb-help-mobile-width';
 const SCREEN_XS_MAX: number = 767;
 const PANEL_HEIGHT: number = 591;
 
@@ -114,8 +115,8 @@ export class BBHelpHelpWidget {
   public open(helpKey: string = this.getHelpKey()) {
     if (!this.widgetDisabled) {
       this.communicationService.postMessage({
-        messageType: 'open-to-help-key',
-        helpKey
+        helpKey,
+        messageType: 'open-to-help-key'
       });
 
       this.analyticsService.trackEvent('Help Widget', {
@@ -142,8 +143,8 @@ export class BBHelpHelpWidget {
     this.currentHelpKey = helpKey;
 
     this.communicationService.postMessage({
-      messageType: 'update-current-help-key',
-      helpKey
+      helpKey,
+      messageType: 'update-current-help-key'
     });
   }
 
@@ -279,12 +280,12 @@ export class BBHelpHelpWidget {
   private setClassesForWindowSize() {
     this.container.classList.add(DISABLE_TRANSITION);
 
-    if (this.isMobileView() && this.isSetForMobile !== true) {
+    if (this.isSetForMobile !== true && (this.isMobileWidth() || this.isMobileHeight())) {
       this.isSetForMobile = true;
       this.container.classList.add(MOBILE_CONTAINER_CLASS);
     }
 
-    if (!this.isMobileView() && this.isSetForMobile !== false) {
+    if (this.isSetForMobile !== false && !this.isMobileWidth() && !this.isMobileHeight()) {
       this.isSetForMobile = false;
       this.container.classList.remove(MOBILE_CONTAINER_CLASS);
     }
@@ -299,8 +300,23 @@ export class BBHelpHelpWidget {
     this.container.classList.remove(DISABLE_TRANSITION);
   }
 
-  private isMobileView(): boolean {
-    return (window.innerWidth <= SCREEN_XS_MAX || window.innerHeight <= PANEL_HEIGHT);
+  private isMobileWidth(): boolean {
+    if (window.innerWidth <= SCREEN_XS_MAX) {
+      if (!this.invoker.classList.contains(MOBILE_WIDTH_CLASS)) {
+        this.invoker.classList.add(MOBILE_WIDTH_CLASS);
+      }
+      return true;
+    }
+
+    if (this.invoker.classList.contains(MOBILE_WIDTH_CLASS)) {
+      this.invoker.classList.remove(MOBILE_WIDTH_CLASS);
+    }
+
+    return false;
+  }
+
+  private isMobileHeight(): boolean {
+    return window.innerHeight <= PANEL_HEIGHT;
   }
 
   private getHelpKey() {


### PR DESCRIPTION
Legacy Help Widget would not hide the invoker tab on mobile height, only mobile width.  This change allows the new widget to mimic this behavior.