### PR TITLE
Added publishToNPM property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@blackbaud/help-client",
   "pipelineSettings": {
-    "publishToCDN": true
+    "publishToCDN": true,
+    "publishToNPM": true
   },
   "version": "2.1.0",
   "description": "Provides a client-side library for interacting with the Help Widget.",


### PR DESCRIPTION
This is to support an upcoming pipeline change.

It does not require an npm publish.