### PR TITLE
fix: move mixpanel-browser to peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.0 (2020-03-06)
+- Fixed package dependency structure to list `mixpanel-browser` as a peer dependency. [#68](https://github.com/blackbaud/help-client/pull/68)
+
 # 2.1.0 (2019-09-06)
 
 - Added `open-widget` message handling. [#64](https://github.com/blackbaud/help-client/pull/64)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "publishToCDN": true,
     "publishToNPM": true
   },
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Provides a client-side library for interacting with the Help Widget.",
   "main": "dist/bundles/help-client.umd.js",
   "module": "index.ts",
@@ -39,11 +39,11 @@
   },
   "homepage": "https://github.com/blackbaud/help-client#readme",
   "dependencies": {
-    "@types/tapable": "0.2.4",
-    "mixpanel-browser": "2.22.4"
+    "@types/tapable": "0.2.4"
   },
   "peerDependencies": {
-    "rxjs": "^6.0.0"
+    "rxjs": "^6.0.0",
+    "mixpanel-browser": "^2.22.4"
   },
   "devDependencies": {
     "@types/core-js": "0.9.41",
@@ -65,6 +65,7 @@
     "karma-mocha-reporter": "2.2.3",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.3",
+    "mixpanel-browser": "2.22.4",
     "node-sass": "4.9.0",
     "raw-loader": "0.5.1",
     "remap-istanbul": "0.9.5",

--- a/src/service/analytics.service.ts
+++ b/src/service/analytics.service.ts
@@ -15,10 +15,14 @@ function getWindow(): any {
   return window;
 }
 
+/**
+ * @deprecated since v2.2.0. This project shouldn't need analytics in the future; all future analytics should be
+ * tracked by the widget itself.
+ */
 export class BBHelpAnalyticsService {
   private superProperties: any;
   private analyticsClient: any;
-  private windowRef: any =  getWindow();
+  private windowRef: any = getWindow();
 
   constructor(mixpanelKeys: MixpanelKeys) {
     PRODUCTION_KEY = mixpanelKeys.PRODUCTION_KEY;


### PR DESCRIPTION
this is to avoid potential clashes with the internal BB analytics lib which declares a MP dependency. i think many haven't had that problem due to `package-lock.json` pinned the dep appropriate. but one team had it bite them.

i entertained just removing MP altogether. the help widget itself has MP and those stats are what we really use. buuuut, it's possible that somebody has some dashboard that has it. (if they do, they probably should update it to use the widget's stats themselves.) so i opted to keep it and just deprecate the service.